### PR TITLE
Add support for github actions

### DIFF
--- a/t/alien_build_plugin_probe_overrideci.t
+++ b/t/alien_build_plugin_probe_overrideci.t
@@ -7,7 +7,7 @@ use File::Temp qw( tempdir );
 
 @INC = map { path($_)->absolute->canonpath } @INC;
 
-delete $ENV{$_} for qw( TRAVIS TRAVIS_BUILD_ROOT APPVEYOR APPVEYOR_BUILD_FOLDER );
+delete $ENV{$_} for qw( TRAVIS TRAVIS_BUILD_ROOT APPVEYOR APPVEYOR_BUILD_FOLDER GITHUB_ACTIONS GITHUB_WORKSPACE );
 
 my $root = path(tempdir ( CLEANUP => 1 ));
 
@@ -25,6 +25,10 @@ my %CI = (
     APPVEYOR              => 'True',
     APPVEYOR_BUILD_FOLDER => $dir1->canonpath,
   },
+  github_actions => {
+    GITHUB_ACTIONS        => 'true',
+    GITHUB_WORKSPACE      => $dir1->canonpath,
+  }
 );
 
 foreach my $ci (sort keys %CI)


### PR DESCRIPTION
Experimenting with [docker-perl-tester](https://github.com/Perl/docker-perl-tester), Github actions and `Probe::OverrideCI` makes this look like the codes I need.

Documentation of these variables can be found at [help.github.com](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables) and [jobs.<job_id>.steps.env](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsenv).